### PR TITLE
Add AGENTS.md with dev notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+This repository houses a Processing sketch demonstrating Reynolds-style autonomous agent behaviors such as seeking, wandering, and obstacle avoidance. The `*.pde` files form the original sketch and should remain unchanged.
+
+The goal of ongoing work is to provide a static HTML5 version using p5.js. Place all new HTML, JavaScript, and related assets under the `docs/` directory so that the sketch can be hosted as a web page. Do **not** modify the existing Processing source files.


### PR DESCRIPTION
## Summary
- document repository purpose
- outline p5.js conversion guidelines in `docs/`

## Testing
- `git status --short`